### PR TITLE
Handle PyTorchTensor[ndarray]

### DIFF
--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -554,8 +554,11 @@ class PyTorchTensor(BaseTensor):
     def __getitem__(self: TensorType, index: Any) -> TensorType:
         if isinstance(index, tuple):
             index = tuple(x.raw if isinstance(x, Tensor) else x for x in index)
-        elif isinstance(index, Tensor):
-            index = index.raw
+        else:
+            if isinstance(index, Tensor):
+                index = index.raw
+            if isinstance(index, np.ndarray):
+                index = torch.as_tensor(index)
         return type(self)(self.raw[index])
 
     def take_along_axis(self: TensorType, index: TensorType, axis: int) -> TensorType:


### PR DESCRIPTION
Hello,

my goal is to work around https://github.com/pytorch/pytorch/issues/34452 .

```python
import torch
import numpy as np
import eagerpy as ep

t=ep.astensor(torch.tensor([0.]))
i=np.array([[0,0],[0,0]])
t[i]
t[ep.astensor(i)]
```

Currently, the last 2 lines fail
> IndexError: too many indices for tensor of dimension 1

The patch lets this test pass. I also ran the testsuite, and it seems to work as well after as before the patch (one jax test fails because of a relative error 1.5295117e-07 > 1e-07 and the first tensorflow test runs forever, but the pytorch tests all pass, which seems the most relevant).

I don't claim that it is the one right way to do it (how do you detect "something that torch.as_tensor likes" more generally than ndarray? Just `try`?). Also, I guess eagerpy is not meant to allow interoperability between types from different backends. However, in some cases, I need to generate some indices, I can easily do it with whatever backend, but I don't know how to conveniently build them with "the same backend as the input", and I see that you already use np.arange to generate an index for a torch.tensor in onehot_like, so it looks acceptable.

It does not solve the same issue with a list or whatever other iterable, but then I can just build a numpy array from those, I only need one way to do this (preferably not one as silly as `t[None,i][0]`).