### PR TITLE
Implement eagerpy.diag

### DIFF
--- a/eagerpy/framework.py
+++ b/eagerpy/framework.py
@@ -175,6 +175,10 @@ def transpose(t: TensorType, axes: Optional[Axes] = None) -> TensorType:
     return t.transpose(axes=axes)
 
 
+def diag(t: TensorType, k: int = 0) -> TensorType:
+    return t._diag(k)
+
+
 @overload
 def logical_and(x: TensorType, y: TensorOrScalar) -> TensorType:
     ...

--- a/eagerpy/framework.py
+++ b/eagerpy/framework.py
@@ -176,7 +176,7 @@ def transpose(t: TensorType, axes: Optional[Axes] = None) -> TensorType:
 
 
 def diag(t: TensorType, k: int = 0) -> TensorType:
-    return t._diag(k)
+    return t.diag(k)
 
 
 @overload

--- a/eagerpy/tensor/jax.py
+++ b/eagerpy/tensor/jax.py
@@ -256,6 +256,9 @@ class JAXTensor(BaseTensor):
             axes = tuple(range(self.ndim - 1, -1, -1))
         return type(self)(np.transpose(self.raw, axes=axes))
 
+    def _diag(self: TensorType, k: int = 0) -> TensorType:
+        return type(self)(np.diag(self.raw, k=k))
+
     def all(
         self: TensorType, axis: Optional[AxisAxes] = None, keepdims: bool = False
     ) -> TensorType:

--- a/eagerpy/tensor/jax.py
+++ b/eagerpy/tensor/jax.py
@@ -256,7 +256,7 @@ class JAXTensor(BaseTensor):
             axes = tuple(range(self.ndim - 1, -1, -1))
         return type(self)(np.transpose(self.raw, axes=axes))
 
-    def _diag(self: TensorType, k: int = 0) -> TensorType:
+    def diag(self: TensorType, k: int = 0) -> TensorType:
         return type(self)(np.diag(self.raw, k=k))
 
     def all(

--- a/eagerpy/tensor/numpy.py
+++ b/eagerpy/tensor/numpy.py
@@ -197,6 +197,9 @@ class NumPyTensor(BaseTensor):
             axes = tuple(range(self.ndim - 1, -1, -1))
         return type(self)(np.transpose(self.raw, axes=axes))
 
+    def _diag(self: TensorType, k: int = 0) -> TensorType:
+        return type(self)(np.diag(self.raw, k=k))
+
     def all(
         self: TensorType, axis: Optional[AxisAxes] = None, keepdims: bool = False
     ) -> TensorType:

--- a/eagerpy/tensor/numpy.py
+++ b/eagerpy/tensor/numpy.py
@@ -197,7 +197,7 @@ class NumPyTensor(BaseTensor):
             axes = tuple(range(self.ndim - 1, -1, -1))
         return type(self)(np.transpose(self.raw, axes=axes))
 
-    def _diag(self: TensorType, k: int = 0) -> TensorType:
+    def diag(self: TensorType, k: int = 0) -> TensorType:
         return type(self)(np.diag(self.raw, k=k))
 
     def all(

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -281,7 +281,7 @@ class PyTorchTensor(BaseTensor):
             axes = tuple(range(self.ndim - 1, -1, -1))
         return type(self)(self.raw.permute(*axes))
 
-    def _diag(self: TensorType, k: int = 0) -> TensorType:
+    def diag(self: TensorType, k: int = 0) -> TensorType:
         return type(self)(torch.diag(self.raw, diagonal=k))
 
     def all(

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -281,6 +281,9 @@ class PyTorchTensor(BaseTensor):
             axes = tuple(range(self.ndim - 1, -1, -1))
         return type(self)(self.raw.permute(*axes))
 
+    def _diag(self: TensorType, k: int = 0) -> TensorType:
+        return type(self)(torch.diag(self.raw, diagonal=k))
+
     def all(
         self: TensorType, axis: Optional[AxisAxes] = None, keepdims: bool = False
     ) -> TensorType:

--- a/eagerpy/tensor/tensor.py
+++ b/eagerpy/tensor/tensor.py
@@ -374,6 +374,10 @@ class Tensor(metaclass=ABCMeta):
         ...
 
     @abstractmethod
+    def _diag(self: TensorType, k: int = 0) -> TensorType:
+        ...
+
+    @abstractmethod
     def take_along_axis(self: TensorType, index: TensorType, axis: int) -> TensorType:
         ...
 

--- a/eagerpy/tensor/tensor.py
+++ b/eagerpy/tensor/tensor.py
@@ -374,7 +374,7 @@ class Tensor(metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    def _diag(self: TensorType, k: int = 0) -> TensorType:
+    def diag(self: TensorType, k: int = 0) -> TensorType:
         ...
 
     @abstractmethod

--- a/eagerpy/tensor/tensorflow.py
+++ b/eagerpy/tensor/tensorflow.py
@@ -263,7 +263,7 @@ class TensorFlowTensor(BaseTensor):
             axes = tuple(range(self.ndim - 1, -1, -1))
         return type(self)(tf.transpose(self.raw, perm=axes))
 
-    def _diag(self: TensorType, k: int = 0) -> TensorType:
+    def diag(self: TensorType, k: int = 0) -> TensorType:
         if len(self.shape) == 1:
             return type(self)(tf.linalg.diag(self.raw, k=k))
         else:

--- a/eagerpy/tensor/tensorflow.py
+++ b/eagerpy/tensor/tensorflow.py
@@ -263,6 +263,12 @@ class TensorFlowTensor(BaseTensor):
             axes = tuple(range(self.ndim - 1, -1, -1))
         return type(self)(tf.transpose(self.raw, perm=axes))
 
+    def _diag(self: TensorType, k: int = 0) -> TensorType:
+        if len(self.shape) == 1:
+            return type(self)(tf.linalg.diag(self.raw, k=k))
+        else:
+            return type(self)(tf.linalg.diag_part(self.raw, k=k))
+
     def all(
         self: TensorType, axis: Optional[AxisAxes] = None, keepdims: bool = False
     ) -> TensorType:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -235,8 +235,61 @@ def test_logical_and_manual(t: Tensor) -> None:
 
 
 def test_transpose_1d(dummy: Tensor) -> None:
-    t = ep.arange(dummy, 8).float32()
+    t = ep.arange(dummy, 4).float32()
     assert (ep.transpose(t) == t).all()
+
+
+def test_diag(dummy: Tensor) -> None:
+
+    t = ep.arange(dummy, 1, 5).float32()
+    d = ep.diag(t)
+    assert d.shape == (4, 4)
+    assert (d.flatten()[[0, 5, 10, 15]] == t).all()
+    assert (ep.index_update(d.flatten(), [0, 5, 10, 15], ep.zeros(dummy, 4)) == 0).all()
+    assert (ep.diag(d) == t).all()
+
+    d = ep.diag(t, k=1)
+    assert d.shape == (5, 5)
+    assert (d.flatten()[[1, 7, 13, 19]] == t).all()
+    assert (ep.index_update(d.flatten(), [1, 7, 13, 19], ep.zeros(dummy, 4)) == 0).all()
+    assert (ep.diag(d, k=1) == t).all()
+
+    d = ep.diag(t, k=2)
+    assert d.shape == (6, 6)
+    assert (d.flatten()[[2, 9, 16, 23]] == t).all()
+    assert (ep.index_update(d.flatten(), [2, 9, 16, 23], ep.zeros(dummy, 4)) == 0).all()
+    assert (ep.diag(d, k=2) == t).all()
+
+    d = ep.diag(t, k=-1)
+    assert d.shape == (5, 5)
+    assert (d.flatten()[[5, 11, 17, 23]] == t).all()
+    assert (
+        ep.index_update(d.flatten(), [5, 11, 17, 23], ep.zeros(dummy, 4)) == 0
+    ).all()
+    assert (ep.diag(d, k=-1) == t).all()
+
+    d = ep.diag(t, k=-2)
+    assert d.shape == (6, 6)
+    assert (d.flatten()[[12, 19, 26, 33]] == t).all()
+    assert (
+        ep.index_update(d.flatten(), [12, 19, 26, 33], ep.zeros(dummy, 4)) == 0
+    ).all()
+    assert (ep.diag(d, k=-2) == t).all()
+
+    t = ep.arange(dummy, 9).float32().reshape((3, 3))
+    assert (ep.diag(t) == t.flatten()[[0, 4, 8]]).all()
+
+    t = ep.arange(dummy, 9).float32().reshape((3, 3))
+    assert (ep.diag(t, k=1) == t.flatten()[[1, 5]]).all()
+
+    t = ep.arange(dummy, 9).float32().reshape((3, 3))
+    assert (ep.diag(t, k=2) == t.flatten()[[2]]).all()
+
+    t = ep.arange(dummy, 9).float32().reshape((3, 3))
+    assert (ep.diag(t, k=-1) == t.flatten()[[3, 7]]).all()
+
+    t = ep.arange(dummy, 9).float32().reshape((3, 3))
+    assert (ep.diag(t, k=-2) == t.flatten()[[6]]).all()
 
 
 def test_onehot_like_raises(dummy: Tensor) -> None:
@@ -1225,6 +1278,42 @@ def test_topk_indices(dummy: Tensor) -> Tensor:
 def test_transpose(dummy: Tensor) -> Tensor:
     t = ep.arange(dummy, 8).float32().reshape((2, 4))
     return ep.transpose(t)
+
+
+@compare_all
+def test_diag_1(dummy: Tensor) -> Tensor:
+    t = ep.arange(dummy, 4).float32()
+    return ep.diag(t)
+
+
+@compare_all
+def test_diag_2(dummy: Tensor) -> Tensor:
+    t = ep.arange(dummy, 4).float32()
+    return ep.diag(t, k=2)
+
+
+@compare_all
+def test_diag_3(dummy: Tensor) -> Tensor:
+    t = ep.arange(dummy, 4).float32()
+    return ep.diag(t, k=-2)
+
+
+@compare_all
+def test_diag_4(dummy: Tensor) -> Tensor:
+    t = ep.arange(dummy, 9).float32().reshape((3, 3))
+    return ep.diag(t)
+
+
+@compare_all
+def test_diag_5(dummy: Tensor) -> Tensor:
+    t = ep.arange(dummy, 9).float32().reshape((3, 3))
+    return ep.diag(t, k=2)
+
+
+@compare_all
+def test_diag_6(dummy: Tensor) -> Tensor:
+    t = ep.arange(dummy, 9).float32().reshape((3, 3))
+    return ep.diag(t, k=-2)
 
 
 @compare_all

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -235,7 +235,7 @@ def test_logical_and_manual(t: Tensor) -> None:
 
 
 def test_transpose_1d(dummy: Tensor) -> None:
-    t = ep.arange(dummy, 4).float32()
+    t = ep.arange(dummy, 8).float32()
     assert (ep.transpose(t) == t).all()
 
 


### PR DESCRIPTION
Closes #21 

Implements `eagerpy.diag`, following `numpy` / `torch` convention:

- Given a one-dimensional tensor, returns a two-dimensional tensor whose diagonal contains the input tensor values, and all other entries are 0. The second (optional) parameter indicates which diagonal to set.
- Given a two-dimensional tensor, returns a one-dimensional tensor containing the values in the diagonal of the input tensor. The second (optional) parameter indicates which diagonal to get.

This cannot handle batched inputs like Tensorflow `linalg.diag` or `linalg.diag_part`, but I think it's cleaner that way, let me know what you think.