### PR TITLE
Add support for topk

### DIFF
--- a/docs/api/tensor.md
+++ b/docs/api/tensor.md
@@ -147,6 +147,11 @@ Tensor.argmax(self:~TensorType, axis:Union[int, NoneType]=None) -> ~TensorType
 Tensor.argsort(self:~TensorType, axis:int=-1) -> ~TensorType
 ```
 
+## topk
+```python
+Tensor.topk(self:~TensorType, k:int, sorted:bool=True) -> ~TensorType
+```
+
 ## uniform
 ```python
 Tensor.uniform(self:~TensorType, shape:Union[Tuple[int, ...], int], low:float=0.0, high:float=1.0) -> ~TensorType

--- a/docs/api/tensor.md
+++ b/docs/api/tensor.md
@@ -149,7 +149,7 @@ Tensor.argsort(self:~TensorType, axis:int=-1) -> ~TensorType
 
 ## topk
 ```python
-Tensor.topk(self:~TensorType, k:int, sorted:bool=True) -> ~TensorType
+Tensor.topk(self:~TensorType, k:int, sorted:bool=True) -> Tuple[~TensorType, ~TensorType]
 ```
 
 ## uniform

--- a/eagerpy/framework.py
+++ b/eagerpy/framework.py
@@ -121,6 +121,9 @@ def argsort(t: TensorType, axis: int = -1) -> TensorType:
 def sort(t: TensorType, axis: int = -1) -> TensorType:
     return t.sort(axis=axis)
 
+def topk(t: TensorType, k: int, sorted: bool = True) -> TensorType:
+    return t.topk(k, sorted=sorted)
+
 
 def uniform(
     t: TensorType, shape: ShapeOrScalar, low: float = 0.0, high: float = 1.0

--- a/eagerpy/framework.py
+++ b/eagerpy/framework.py
@@ -121,7 +121,7 @@ def argsort(t: TensorType, axis: int = -1) -> TensorType:
 def sort(t: TensorType, axis: int = -1) -> TensorType:
     return t.sort(axis=axis)
 
-def topk(t: TensorType, k: int, sorted: bool = True) -> TensorType:
+def topk(t: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
     return t.topk(k, sorted=sorted)
 
 

--- a/eagerpy/framework.py
+++ b/eagerpy/framework.py
@@ -121,6 +121,7 @@ def argsort(t: TensorType, axis: int = -1) -> TensorType:
 def sort(t: TensorType, axis: int = -1) -> TensorType:
     return t.sort(axis=axis)
 
+
 def topk(t: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
     return t.topk(k, sorted=sorted)
 

--- a/eagerpy/tensor/jax.py
+++ b/eagerpy/tensor/jax.py
@@ -174,7 +174,7 @@ class JAXTensor(BaseTensor):
     def sort(self: TensorType, axis: int = -1) -> TensorType:
         return type(self)(self.raw.sort(axis=axis))
 
-    def topk(self: TensorType, k: int, sorted: bool = True) -> TensorType:
+    def topk(self: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
         # argpartition not yet implemented
         # wrapping indexing not supported in take()
         n = self.raw.shape[-1]

--- a/eagerpy/tensor/jax.py
+++ b/eagerpy/tensor/jax.py
@@ -174,6 +174,18 @@ class JAXTensor(BaseTensor):
     def sort(self: TensorType, axis: int = -1) -> TensorType:
         return type(self)(self.raw.sort(axis=axis))
 
+    def topk(self: TensorType, k: int, sorted: bool = True) -> TensorType:
+        # argpartition not yet implemented
+        # wrapping indexing not supported in take()
+        n = self.raw.shape[-1]
+        idx = np.take(np.argsort(self.raw), np.arange(n - k, n), axis = -1)
+        val = np.take_along_axis(self.raw, idx, axis = -1)
+        if sorted:
+            perm = np.flip(np.argsort(val, axis = -1), axis = -1)
+            idx = np.take_along_axis(idx, perm, axis = -1)
+            val = np.take_along_axis(self.raw, idx, axis = -1)
+        return type(self)(val), type(self)(idx)
+
     def uniform(
         self: TensorType, shape: ShapeOrScalar, low: float = 0.0, high: float = 1.0
     ) -> TensorType:

--- a/eagerpy/tensor/jax.py
+++ b/eagerpy/tensor/jax.py
@@ -174,16 +174,18 @@ class JAXTensor(BaseTensor):
     def sort(self: TensorType, axis: int = -1) -> TensorType:
         return type(self)(self.raw.sort(axis=axis))
 
-    def topk(self: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
+    def topk(
+        self: TensorType, k: int, sorted: bool = True
+    ) -> Tuple[TensorType, TensorType]:
         # argpartition not yet implemented
         # wrapping indexing not supported in take()
         n = self.raw.shape[-1]
-        idx = np.take(np.argsort(self.raw), np.arange(n - k, n), axis = -1)
-        val = np.take_along_axis(self.raw, idx, axis = -1)
+        idx = np.take(np.argsort(self.raw), np.arange(n - k, n), axis=-1)
+        val = np.take_along_axis(self.raw, idx, axis=-1)
         if sorted:
-            perm = np.flip(np.argsort(val, axis = -1), axis = -1)
-            idx = np.take_along_axis(idx, perm, axis = -1)
-            val = np.take_along_axis(self.raw, idx, axis = -1)
+            perm = np.flip(np.argsort(val, axis=-1), axis=-1)
+            idx = np.take_along_axis(idx, perm, axis=-1)
+            val = np.take_along_axis(self.raw, idx, axis=-1)
         return type(self)(val), type(self)(idx)
 
     def uniform(

--- a/eagerpy/tensor/numpy.py
+++ b/eagerpy/tensor/numpy.py
@@ -125,13 +125,15 @@ class NumPyTensor(BaseTensor):
     def sort(self: TensorType, axis: int = -1) -> TensorType:
         return type(self)(np.sort(self.raw, axis=axis))
 
-    def topk(self: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
-        idx = np.take(np.argpartition(self.raw, k - 1), np.arange(-k, 0), axis = -1)
-        val = np.take_along_axis(self.raw, idx, axis = -1)
+    def topk(
+        self: TensorType, k: int, sorted: bool = True
+    ) -> Tuple[TensorType, TensorType]:
+        idx = np.take(np.argpartition(self.raw, k - 1), np.arange(-k, 0), axis=-1)
+        val = np.take_along_axis(self.raw, idx, axis=-1)
         if sorted:
-            perm = np.flip(np.argsort(val, axis = -1), axis = -1)
-            idx = np.take_along_axis(idx, perm, axis = -1)
-            val = np.take_along_axis(self.raw, idx, axis = -1)
+            perm = np.flip(np.argsort(val, axis=-1), axis=-1)
+            idx = np.take_along_axis(idx, perm, axis=-1)
+            val = np.take_along_axis(self.raw, idx, axis=-1)
         return type(self)(val), type(self)(idx)
 
     def uniform(

--- a/eagerpy/tensor/numpy.py
+++ b/eagerpy/tensor/numpy.py
@@ -125,6 +125,15 @@ class NumPyTensor(BaseTensor):
     def sort(self: TensorType, axis: int = -1) -> TensorType:
         return type(self)(np.sort(self.raw, axis=axis))
 
+    def topk(self: TensorType, k: int, sorted: bool = True) -> TensorType:
+        idx = np.take(np.argpartition(self.raw, k - 1), np.arange(-k, 0), axis = -1)
+        val = np.take_along_axis(self.raw, idx, axis = -1)
+        if sorted:
+            perm = np.flip(np.argsort(val, axis = -1), axis = -1)
+            idx = np.take_along_axis(idx, perm, axis = -1)
+            val = np.take_along_axis(self.raw, idx, axis = -1)
+        return type(self)(val), type(self)(idx)
+
     def uniform(
         self: TensorType, shape: ShapeOrScalar, low: float = 0.0, high: float = 1.0
     ) -> TensorType:

--- a/eagerpy/tensor/numpy.py
+++ b/eagerpy/tensor/numpy.py
@@ -125,7 +125,7 @@ class NumPyTensor(BaseTensor):
     def sort(self: TensorType, axis: int = -1) -> TensorType:
         return type(self)(np.sort(self.raw, axis=axis))
 
-    def topk(self: TensorType, k: int, sorted: bool = True) -> TensorType:
+    def topk(self: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
         idx = np.take(np.argpartition(self.raw, k - 1), np.arange(-k, 0), axis = -1)
         val = np.take_along_axis(self.raw, idx, axis = -1)
         if sorted:

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -206,8 +206,8 @@ class PyTorchTensor(BaseTensor):
     def topk(
         self: TensorType, k: int, sorted: bool = True
     ) -> Tuple[TensorType, TensorType]:
-        pair = self.raw.topk(k, sorted=sorted)
-        return type(self)(pair[0]), type(self)(pair[1])
+        values, indices = self.raw.topk(k, sorted=sorted)
+        return type(self)(values), type(self)(indices)
 
     def uniform(
         self: TensorType, shape: ShapeOrScalar, low: float = 0.0, high: float = 1.0

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -203,7 +203,7 @@ class PyTorchTensor(BaseTensor):
     def sort(self: TensorType, axis: int = -1) -> TensorType:
         return type(self)(self.raw.sort(dim=axis).values)  # type: ignore
 
-    def topk(self: TensorType, k: int, sorted: bool = True) -> TensorType:
+    def topk(self: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
         pair = self.raw.topk(k, sorted=sorted)
         return type(self)(pair[0]), type(self)(pair[1])
 

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -203,6 +203,10 @@ class PyTorchTensor(BaseTensor):
     def sort(self: TensorType, axis: int = -1) -> TensorType:
         return type(self)(self.raw.sort(dim=axis).values)  # type: ignore
 
+    def topk(self: TensorType, k: int, sorted: bool = True) -> TensorType:
+        pair = self.raw.topk(k, sorted=sorted)
+        return type(self)(pair[0]), type(self)(pair[1])
+
     def uniform(
         self: TensorType, shape: ShapeOrScalar, low: float = 0.0, high: float = 1.0
     ) -> TensorType:

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -203,7 +203,9 @@ class PyTorchTensor(BaseTensor):
     def sort(self: TensorType, axis: int = -1) -> TensorType:
         return type(self)(self.raw.sort(dim=axis).values)  # type: ignore
 
-    def topk(self: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
+    def topk(
+        self: TensorType, k: int, sorted: bool = True
+    ) -> Tuple[TensorType, TensorType]:
         pair = self.raw.topk(k, sorted=sorted)
         return type(self)(pair[0]), type(self)(pair[1])
 

--- a/eagerpy/tensor/tensor.py
+++ b/eagerpy/tensor/tensor.py
@@ -310,7 +310,9 @@ class Tensor(metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    def topk(self: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
+    def topk(
+        self: TensorType, k: int, sorted: bool = True
+    ) -> Tuple[TensorType, TensorType]:
         ...
 
     @abstractmethod

--- a/eagerpy/tensor/tensor.py
+++ b/eagerpy/tensor/tensor.py
@@ -310,6 +310,10 @@ class Tensor(metaclass=ABCMeta):
         ...
 
     @abstractmethod
+    def topk(self: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
+        ...
+
+    @abstractmethod
     def uniform(
         self: TensorType, shape: ShapeOrScalar, low: float = 0.0, high: float = 1.0
     ) -> TensorType:

--- a/eagerpy/tensor/tensorflow.py
+++ b/eagerpy/tensor/tensorflow.py
@@ -176,7 +176,7 @@ class TensorFlowTensor(BaseTensor):
     def sort(self: TensorType, axis: Optional[int] = -1) -> TensorType:
         return type(self)(tf.sort(self.raw, axis=axis))
 
-    def topk(self: TensorType, k: int, sorted: bool = True) -> TensorType:
+    def topk(self: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
         pair = tf.math.top_k(self.raw, k, sorted=sorted)
         return type(self)(pair[0]), type(self)(pair[1])
 

--- a/eagerpy/tensor/tensorflow.py
+++ b/eagerpy/tensor/tensorflow.py
@@ -176,6 +176,10 @@ class TensorFlowTensor(BaseTensor):
     def sort(self: TensorType, axis: Optional[int] = -1) -> TensorType:
         return type(self)(tf.sort(self.raw, axis=axis))
 
+    def topk(self: TensorType, k: int, sorted: bool = True) -> TensorType:
+        pair = tf.math.top_k(self.raw, k, sorted=sorted)
+        return type(self)(pair[0]), type(self)(pair[1])
+
     @samedevice
     def uniform(
         self: TensorType, shape: ShapeOrScalar, low: float = 0.0, high: float = 1.0

--- a/eagerpy/tensor/tensorflow.py
+++ b/eagerpy/tensor/tensorflow.py
@@ -176,7 +176,9 @@ class TensorFlowTensor(BaseTensor):
     def sort(self: TensorType, axis: Optional[int] = -1) -> TensorType:
         return type(self)(tf.sort(self.raw, axis=axis))
 
-    def topk(self: TensorType, k: int, sorted: bool = True) -> Tuple[TensorType, TensorType]:
+    def topk(
+        self: TensorType, k: int, sorted: bool = True
+    ) -> Tuple[TensorType, TensorType]:
         pair = tf.math.top_k(self.raw, k, sorted=sorted)
         return type(self)(pair[0]), type(self)(pair[1])
 

--- a/eagerpy/tensor/tensorflow.py
+++ b/eagerpy/tensor/tensorflow.py
@@ -179,8 +179,8 @@ class TensorFlowTensor(BaseTensor):
     def topk(
         self: TensorType, k: int, sorted: bool = True
     ) -> Tuple[TensorType, TensorType]:
-        pair = tf.math.top_k(self.raw, k, sorted=sorted)
-        return type(self)(pair[0]), type(self)(pair[1])
+        values, indices = tf.math.top_k(self.raw, k, sorted=sorted)
+        return type(self)(values), type(self)(indices)
 
     @samedevice
     def uniform(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1205,10 +1205,12 @@ def test_sort(dummy: Tensor) -> Tensor:
     t = -ep.arange(dummy, 6).float32().reshape((2, 3))
     return ep.sort(t)
 
+
 @compare_all
 def test_topk_0(dummy: Tensor) -> Tensor:
     t = ep.arange(dummy, 27).float32().reshape((3, 3, 3))
     return ep.topk(t, 2)[0]
+
 
 @compare_all
 def test_topk_1(dummy: Tensor) -> Tensor:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1208,14 +1208,14 @@ def test_sort(dummy: Tensor) -> Tensor:
 
 @compare_all
 def test_topk_values(dummy: Tensor) -> Tensor:
-    t = ep.arange(dummy, 27).float32().reshape((3, 3, 3))
+    t = ep.arange(dummy, 27).float32().reshape((3, 3, 3)) ** 2 % 0.1234
     values, _ = ep.topk(t, 2)
     return values
 
 
 @compare_all
 def test_topk_indices(dummy: Tensor) -> Tensor:
-    t = -ep.arange(dummy, 27).float32().reshape((3, 3, 3))
+    t = -ep.arange(dummy, 27).float32().reshape((3, 3, 3)) ** 2 % 0.1234
     _, indices = ep.topk(t, 2)
     return indices
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1207,15 +1207,17 @@ def test_sort(dummy: Tensor) -> Tensor:
 
 
 @compare_all
-def test_topk_0(dummy: Tensor) -> Tensor:
+def test_topk_values(dummy: Tensor) -> Tensor:
     t = ep.arange(dummy, 27).float32().reshape((3, 3, 3))
-    return ep.topk(t, 2)[0]
+    values, _ = ep.topk(t, 2)
+    return values
 
 
 @compare_all
-def test_topk_1(dummy: Tensor) -> Tensor:
+def test_topk_indices(dummy: Tensor) -> Tensor:
     t = -ep.arange(dummy, 27).float32().reshape((3, 3, 3))
-    return ep.topk(t, 2)[1]
+    _, indices = ep.topk(t, 2)
+    return indices
 
 
 @compare_all

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1205,6 +1205,16 @@ def test_sort(dummy: Tensor) -> Tensor:
     t = -ep.arange(dummy, 6).float32().reshape((2, 3))
     return ep.sort(t)
 
+@compare_all
+def test_topk_0(dummy: Tensor) -> Tensor:
+    t = ep.arange(dummy, 27).float32().reshape((3, 3, 3))
+    return ep.topk(t, 2)[0]
+
+@compare_all
+def test_topk_1(dummy: Tensor) -> Tensor:
+    t = -ep.arange(dummy, 27).float32().reshape((3, 3, 3))
+    return ep.topk(t, 2)[1]
+
 
 @compare_all
 def test_transpose(dummy: Tensor) -> Tensor:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1208,14 +1208,14 @@ def test_sort(dummy: Tensor) -> Tensor:
 
 @compare_all
 def test_topk_values(dummy: Tensor) -> Tensor:
-    t = ep.arange(dummy, 27).float32().reshape((3, 3, 3)) ** 2 % 0.1234
+    t = (ep.arange(dummy, 27).reshape((3, 3, 3)) ** 2 * 10000 % 1234).float32()
     values, _ = ep.topk(t, 2)
     return values
 
 
 @compare_all
 def test_topk_indices(dummy: Tensor) -> Tensor:
-    t = -ep.arange(dummy, 27).float32().reshape((3, 3, 3)) ** 2 % 0.1234
+    t = -(ep.arange(dummy, 27).reshape((3, 3, 3)) ** 2 * 10000 % 1234).float32()
     _, indices = ep.topk(t, 2)
     return indices
 


### PR DESCRIPTION
Fix #23.
This adds a minimal version of topk. In the future, it would be good to add some version of the `dim` and `largest` arguments from `torch.topk` (I use them), but I wanted to start with the basic functionality. The numpy version is a bit more complicated than one might hope, and jax complicates it further by not supporting `argpartition` and silently behaving differently in `take`.
I wasn't sure about the documentation, I searched for "sort" in docs/ and only found argsort in api/tensor.md, so I added topk there...