### PR TITLE
Jax tensors are not correctly recognized if they are stored on GPUs

### DIFF
--- a/eagerpy/astensor.py
+++ b/eagerpy/astensor.py
@@ -43,6 +43,11 @@ def astensor(x: Union[NativeTensor, Tensor]) -> Tensor:  # type: ignore
     # to avoid importing all the frameworks
     name = _get_module_name(x)
     m = sys.modules
+    # jax might use jax or the jaxlib namespace
+    # this is necessary for running jax on gpus
+    if name == "jaxlib":
+        name = "jax"
+
     if name == "torch" and isinstance(x, m[name].Tensor):  # type: ignore
         return PyTorchTensor(x)
     if name == "tensorflow" and isinstance(x, m[name].Tensor):  # type: ignore

--- a/eagerpy/astensor.py
+++ b/eagerpy/astensor.py
@@ -43,16 +43,12 @@ def astensor(x: Union[NativeTensor, Tensor]) -> Tensor:  # type: ignore
     # to avoid importing all the frameworks
     name = _get_module_name(x)
     m = sys.modules
-    # jax might use jax or the jaxlib namespace
-    # this is necessary for running jax on gpus
-    if name == "jaxlib":
-        name = "jax"
 
     if name == "torch" and isinstance(x, m[name].Tensor):  # type: ignore
         return PyTorchTensor(x)
     if name == "tensorflow" and isinstance(x, m[name].Tensor):  # type: ignore
         return TensorFlowTensor(x)
-    if name == "jax" and isinstance(x, m[name].numpy.ndarray):  # type: ignore
+    if (name == "jax" or name == "jaxlib") and isinstance(x, m["jax"].numpy.ndarray):  # type: ignore
         return JAXTensor(x)
     if name == "numpy" and isinstance(x, m[name].ndarray):  # type: ignore
         return NumPyTensor(x)


### PR DESCRIPTION
I noticed that the conversion of `ndarray`s in `JAX` to `JAXTensors` in `eagerpy` does not work on machines with GPUs, since here `JAX` will use the `jaxlib` namespace to represent the array s(as `DeviceArray`s) instead of the normal `jax` namespace. This PR adds `jaxlib` as an alias to detect `JAX` tensors.