### PR TITLE
Introduce wrapper eager_function

### DIFF
--- a/eagerpy/__init__.py
+++ b/eagerpy/__init__.py
@@ -33,6 +33,7 @@ from .astensor import astensor  # noqa: F401,E402
 from .astensor import astensors  # noqa: F401,E402
 from .astensor import astensor_  # noqa: F401,E402
 from .astensor import astensors_  # noqa: F401,E402
+from .astensor import eager_function  # noqa: F401,E402
 
 from .modules import torch  # noqa: F401,E402
 from .modules import tensorflow  # noqa: F401,E402

--- a/eagerpy/astensor.py
+++ b/eagerpy/astensor.py
@@ -173,23 +173,12 @@ def as_raw_tensors(data: Any) -> Any:
     return tree_unflatten(tree_def, unwrap_leaf_values)
 
 
-def eager_function(
-    func: Callable[..., T], skip_argnums: Tuple = tuple()
-) -> Callable[..., T]:
+def eager_function(func: Callable[..., T]) -> Callable[..., T]:
     @functools.wraps(func)
     def eager_func(*args: Any, **kwargs: Any) -> Any:
-        sorted_skip_argnums = sorted(skip_argnums)
-        skip_args = [arg for i, arg in enumerate(args) if i in sorted_skip_argnums]
-        kept_args = [arg for i, arg in enumerate(args) if i not in sorted_skip_argnums]
-
-        (kept_args, kwargs), has_tensor = as_tensors_any((kept_args, kwargs))
+        (args, kwargs), has_tensor = as_tensors_any((args, kwargs))
         unwrap = not has_tensor
-
-        for i, arg in zip(sorted_skip_argnums, skip_args):
-            kept_args.insert(i, arg)
-
-        result = func(*kept_args, **kwargs)
-
+        result = func(*args, **kwargs)
         if unwrap:
             raw_result = as_raw_tensors(result)
             return raw_result

--- a/eagerpy/astensor.py
+++ b/eagerpy/astensor.py
@@ -48,7 +48,7 @@ def astensor(x: NativeTensor) -> Tensor:  # type: ignore
     ...
 
 
-def astensor(x: Union[NativeTensor, Tensor]) -> Tensor:  # type: ignore
+def astensor(x: Union[NativeTensor, Tensor, Any]) -> Union[Tensor, Any]:  # type: ignore
     if isinstance(x, Tensor):
         return x
     # we use the module name instead of isinstance
@@ -64,7 +64,8 @@ def astensor(x: Union[NativeTensor, Tensor]) -> Tensor:  # type: ignore
         return JAXTensor(x)
     if name == "numpy" and isinstance(x, m[name].ndarray):  # type: ignore
         return NumPyTensor(x)
-    raise ValueError(f"Unknown type: {type(x)}")
+    return x
+    # raise ValueError(f"Unknown type: {type(x)}")
 
 
 def astensors(*xs: Union[NativeTensor, Tensor]) -> Tuple[Tensor, ...]:  # type: ignore

--- a/eagerpy/tensor/extensions.py
+++ b/eagerpy/tensor/extensions.py
@@ -6,7 +6,6 @@ from .. import norms
 
 from .tensor import Tensor
 
-
 T = TypeVar("T")
 
 

--- a/eagerpy/tensor/jax.py
+++ b/eagerpy/tensor/jax.py
@@ -58,7 +58,6 @@ def getitem_preprocess(x: Any) -> Any:
 
 class JAXTensor(BaseTensor):
     __slots__ = ()
-
     # more specific types for the extensions
     norms: "NormsMethods[JAXTensor]"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1643,7 +1643,7 @@ def test_eager_function_return_non_registered_datastruct(
 
 # define a non-registered pytree container.
 class MyClass:
-    @functools.partial(eager_function, skip_argnums=(0,))
+    @eager_function
     def my_universal_method(self, a: Tensor, b: Tensor, c: Tensor) -> Any:
         res = (a + b * c).square()
         return res

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1661,3 +1661,22 @@ def test_eager_function_on_method(t: Tensor, astensor: bool) -> Tensor:
     result = MyClass().my_universal_method(a, b, c)
     assert isinstance(result, type(a))
     return ep.astensor(result)
+
+
+@eager_function
+def my_universal_function_with_non_tensors(a: int, b: Tensor, c: Tensor) -> Tensor:
+    return (a + b * c).square()
+
+
+@pytest.mark.parametrize("astensor", [False, True])
+@compare_all
+def test_eager_function_with_non_tensors(t: Tensor, astensor: bool) -> Tensor:
+    if astensor:
+        b = t
+    else:
+        b = t.raw
+    a = 3
+    c = b
+    result = my_universal_function_with_non_tensors(a, b, c)
+    assert isinstance(result, type(b))
+    return ep.astensor(result)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ import functools
 import itertools
 import numpy as np
 import eagerpy as ep
-from eagerpy import Tensor
+from eagerpy import Tensor, eager_function
 from eagerpy.types import Shape, AxisAxes
 
 # make sure there are no undecorated tests in the "special tests" section below
@@ -147,6 +147,7 @@ def test_value_and_grad_fn(dummy: Tensor) -> None:
     if isinstance(dummy, ep.NumPyTensor):
         pytest.skip()
 
+    @eager_function
     def f(x: ep.Tensor) -> ep.Tensor:
         return x.square().sum()
 
@@ -161,6 +162,7 @@ def test_value_and_grad_fn_with_aux(dummy: Tensor) -> None:
     if isinstance(dummy, ep.NumPyTensor):
         pytest.skip()
 
+    @eager_function
     def f(x: Tensor) -> Tuple[Tensor, Tensor]:
         x = x.square()
         return x.sum(), x
@@ -177,6 +179,7 @@ def test_value_and_grad(dummy: Tensor) -> None:
     if isinstance(dummy, ep.NumPyTensor):
         pytest.skip()
 
+    @eager_function
     def f(x: Tensor) -> Tensor:
         return x.square().sum()
 
@@ -190,6 +193,7 @@ def test_value_aux_and_grad(dummy: Tensor) -> None:
     if isinstance(dummy, ep.NumPyTensor):
         pytest.skip()
 
+    @eager_function
     def f(x: Tensor) -> Tuple[Tensor, Tensor]:
         x = x.square()
         return x.sum(), x
@@ -205,6 +209,7 @@ def test_value_aux_and_grad_multiple_aux(dummy: Tensor) -> None:
     if isinstance(dummy, ep.NumPyTensor):
         pytest.skip()
 
+    @eager_function
     def f(x: Tensor) -> Tuple[Tensor, Tuple[Tensor, Tensor]]:
         x = x.square()
         return x.sum(), (x, x + 1)
@@ -221,6 +226,7 @@ def test_value_and_grad_multiple_args(dummy: Tensor) -> None:
     if isinstance(dummy, ep.NumPyTensor):
         pytest.skip()
 
+    @eager_function
     def f(x: Tensor, y: Tensor) -> Tensor:
         return (x * y).sum()
 
@@ -1581,3 +1587,77 @@ def test_norms_lp(t: Tensor) -> Tensor:
 @compare_all
 def test_norms_cache(t: Tensor) -> Tensor:
     return t.norms.l1() + t.norms.l2()
+
+
+@eager_function
+def my_universal_function(a: Tensor, b: Tensor, c: Tensor) -> Tensor:
+    return (a + b * c).square()
+
+
+@pytest.mark.parametrize("astensor", [False, True])
+@compare_all
+def test_eager_function(t: Tensor, astensor: bool) -> Tensor:
+    if astensor:
+        a = t
+    else:
+        a = t.raw
+    b = a
+    c = a
+    result = my_universal_function(a, b, c)
+    assert isinstance(result, type(a))
+    return ep.astensor(result)
+
+
+# define a non-registered pytree container.
+class NonRegisteredDataStruct:
+    def __init__(self, res: Any) -> None:
+        self.res = res
+
+
+@eager_function
+def my_universal_function_return_non_registered_datastruct(
+    a: Tensor, b: Tensor, c: Tensor
+) -> Any:
+    res = (a + b * c).square()
+    return NonRegisteredDataStruct(res)
+
+
+@pytest.mark.parametrize("astensor", [False, True])
+@compare_all
+def test_eager_function_return_non_registered_datastruct(
+    t: Tensor, astensor: bool
+) -> Tensor:
+    if astensor:
+        a = t
+    else:
+        a = t.raw
+    b = a
+    c = a
+    result = my_universal_function_return_non_registered_datastruct(a, b, c)
+
+    # result has not been converted because NonRegisteredSpecial
+    # is not a registered pytree container
+    assert isinstance(result.res, type(t))
+    return ep.astensor(result.res)
+
+
+# define a non-registered pytree container.
+class MyClass:
+    @functools.partial(eager_function, skip_argnums=(0,))
+    def my_universal_method(self, a: Tensor, b: Tensor, c: Tensor) -> Any:
+        res = (a + b * c).square()
+        return res
+
+
+@pytest.mark.parametrize("astensor", [False, True])
+@compare_all
+def test_eager_function_on_method(t: Tensor, astensor: bool) -> Tensor:
+    if astensor:
+        a = t
+    else:
+        a = t.raw
+    b = a
+    c = a
+    result = MyClass().my_universal_method(a, b, c)
+    assert isinstance(result, type(a))
+    return ep.astensor(result)


### PR DESCRIPTION
Introduce as_tensors, as_tensors_, as_raw_tensor, as_raw_tensors that rely in tree_flatten/tree_unflatten for more generic usages
JaxTensor is no longer registered as a pytree datastructure
Refactor JaxTensor._value_and_grad_fn

Fix https://github.com/jonasrauber/eagerpy/issues/34