### PR TITLE
Add basic trigonometric functions

### DIFF
--- a/docs/api/tensor.md
+++ b/docs/api/tensor.md
@@ -33,11 +33,6 @@ Tensor.sign(self:~TensorType) -> ~TensorType
 Tensor.sqrt(self:~TensorType) -> ~TensorType
 ```
 
-## tanh
-```python
-Tensor.tanh(self:~TensorType) -> ~TensorType
-```
-
 ## float32
 ```python
 Tensor.float32(self:~TensorType) -> ~TensorType
@@ -90,6 +85,61 @@ Tensor.clip(self:~TensorType, min_:float, max_:float) -> ~TensorType
 ## square
 ```python
 Tensor.square(self:~TensorType) -> ~TensorType
+```
+
+## sin
+```python
+Tensor.sin(self:~TensorType) -> ~TensorType
+```
+
+## cos
+```python
+Tensor.cos(self:~TensorType) -> ~TensorType
+```
+
+## tan
+```python
+Tensor.tan(self:~TensorType) -> ~TensorType
+```
+
+## sinh
+```python
+Tensor.sinh(self:~TensorType) -> ~TensorType
+```
+
+## cosh
+```python
+Tensor.cosh(self:~TensorType) -> ~TensorType
+```
+
+## tanh
+```python
+Tensor.tanh(self:~TensorType) -> ~TensorType
+```
+
+## arcsin
+```python
+Tensor.arcsin(self:~TensorType) -> ~TensorType
+```
+
+## arccos
+```python
+Tensor.arccos(self:~TensorType) -> ~TensorType
+```
+
+## arctan
+```python
+Tensor.arctan(self:~TensorType) -> ~TensorType
+```
+
+## arcsinh
+```python
+Tensor.arcsinh(self:~TensorType) -> ~TensorType
+```
+
+## arccosh
+```python
+Tensor.arccosh(self:~TensorType) -> ~TensorType
 ```
 
 ## arctanh

--- a/eagerpy/framework.py
+++ b/eagerpy/framework.py
@@ -36,8 +36,48 @@ def pow(t: TensorType, exponent: TensorOrScalar) -> TensorType:
     return t.pow(exponent)
 
 
+def sin(t: TensorType) -> TensorType:
+    return t.sin()
+
+
+def cos(t: TensorType) -> TensorType:
+    return t.cos()
+
+
+def tan(t: TensorType) -> TensorType:
+    return t.tan()
+
+
+def arcsin(t: TensorType) -> TensorType:
+    return t.arcsin()
+
+
+def arccos(t: TensorType) -> TensorType:
+    return t.arccos()
+
+
+def arctan(t: TensorType) -> TensorType:
+    return t.arctan()
+
+
+def sinh(t: TensorType) -> TensorType:
+    return t.sinh()
+
+
+def cosh(t: TensorType) -> TensorType:
+    return t.cosh()
+
+
 def tanh(t: TensorType) -> TensorType:
     return t.tanh()
+
+
+def arcsinh(t: TensorType) -> TensorType:
+    return t.arcsinh()
+
+
+def arccosh(t: TensorType) -> TensorType:
+    return t.arccosh()
 
 
 def arctanh(t: TensorType) -> TensorType:

--- a/eagerpy/tensor/jax.py
+++ b/eagerpy/tensor/jax.py
@@ -124,9 +124,6 @@ class JAXTensor(BaseTensor):
     def square(self: TensorType) -> TensorType:
         return type(self)(np.square(self.raw))
 
-    def arctanh(self: TensorType) -> TensorType:
-        return type(self)(np.arctanh(self.raw))
-
     def sum(
         self: TensorType, axis: Optional[AxisAxes] = None, keepdims: bool = False
     ) -> TensorType:
@@ -483,8 +480,41 @@ class JAXTensor(BaseTensor):
     def sqrt(self: TensorType) -> TensorType:
         return type(self)(np.sqrt(self.raw))
 
+    def sin(self: TensorType) -> TensorType:
+        return type(self)(np.sin(self.raw))
+
+    def cos(self: TensorType) -> TensorType:
+        return type(self)(np.cos(self.raw))
+
+    def tan(self: TensorType) -> TensorType:
+        return type(self)(np.tan(self.raw))
+
+    def sinh(self: TensorType) -> TensorType:
+        return type(self)(np.sinh(self.raw))
+
+    def cosh(self: TensorType) -> TensorType:
+        return type(self)(np.cosh(self.raw))
+
     def tanh(self: TensorType) -> TensorType:
         return type(self)(np.tanh(self.raw))
+
+    def arcsin(self: TensorType) -> TensorType:
+        return type(self)(np.arcsin(self.raw))
+
+    def arccos(self: TensorType) -> TensorType:
+        return type(self)(np.arccos(self.raw))
+
+    def arctan(self: TensorType) -> TensorType:
+        return type(self)(np.arctan(self.raw))
+
+    def arcsinh(self: TensorType) -> TensorType:
+        return type(self)(np.arcsinh(self.raw))
+
+    def arccosh(self: TensorType) -> TensorType:
+        return type(self)(np.arccosh(self.raw))
+
+    def arctanh(self: TensorType) -> TensorType:
+        return type(self)(np.arctanh(self.raw))
 
     def float32(self: TensorType) -> TensorType:
         return self.astype(np.float32)

--- a/eagerpy/tensor/numpy.py
+++ b/eagerpy/tensor/numpy.py
@@ -75,9 +75,6 @@ class NumPyTensor(BaseTensor):
     def square(self: TensorType) -> TensorType:
         return type(self)(np.square(self.raw))
 
-    def arctanh(self: TensorType) -> TensorType:
-        return type(self)(np.arctanh(self.raw))
-
     def sum(
         self: TensorType, axis: Optional[AxisAxes] = None, keepdims: bool = False
     ) -> TensorType:
@@ -388,8 +385,41 @@ class NumPyTensor(BaseTensor):
     def sqrt(self: TensorType) -> TensorType:
         return type(self)(np.sqrt(self.raw))
 
+    def sin(self: TensorType) -> TensorType:
+        return type(self)(np.sin(self.raw))
+
+    def cos(self: TensorType) -> TensorType:
+        return type(self)(np.cos(self.raw))
+
+    def tan(self: TensorType) -> TensorType:
+        return type(self)(np.tan(self.raw))
+
+    def sinh(self: TensorType) -> TensorType:
+        return type(self)(np.sinh(self.raw))
+
+    def cosh(self: TensorType) -> TensorType:
+        return type(self)(np.cosh(self.raw))
+
     def tanh(self: TensorType) -> TensorType:
         return type(self)(np.tanh(self.raw))
+
+    def arcsin(self: TensorType) -> TensorType:
+        return type(self)(np.arcsin(self.raw))
+
+    def arccos(self: TensorType) -> TensorType:
+        return type(self)(np.arccos(self.raw))
+
+    def arctan(self: TensorType) -> TensorType:
+        return type(self)(np.arctan(self.raw))
+
+    def arcsinh(self: TensorType) -> TensorType:
+        return type(self)(np.arcsinh(self.raw))
+
+    def arccosh(self: TensorType) -> TensorType:
+        return type(self)(np.arccosh(self.raw))
+
+    def arctanh(self: TensorType) -> TensorType:
+        return type(self)(np.arctanh(self.raw))
 
     def float32(self: TensorType) -> TensorType:
         return self.astype(np.float32)

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -58,9 +58,6 @@ class PyTorchTensor(BaseTensor):
     def raw(self) -> "torch.Tensor":
         return cast(torch.Tensor, super().raw)
 
-    def tanh(self: TensorType) -> TensorType:
-        return type(self)(torch.tanh(self.raw))
-
     def numpy(self: TensorType) -> Any:
         a = self.raw.detach().cpu().numpy()
         if a.flags.writeable:
@@ -90,12 +87,52 @@ class PyTorchTensor(BaseTensor):
     def square(self: TensorType) -> TensorType:
         return type(self)(self.raw ** 2)
 
+    def sin(self: TensorType) -> TensorType:
+        return type(self)(torch.sin(self.raw))
+
+    def cos(self: TensorType) -> TensorType:
+        return type(self)(torch.cos(self.raw))
+
+    def tan(self: TensorType) -> TensorType:
+        return type(self)(torch.tan(self.raw))
+
+    def sinh(self: TensorType) -> TensorType:
+        return type(self)(torch.sinh(self.raw))
+
+    def cosh(self: TensorType) -> TensorType:
+        return type(self)(torch.cosh(self.raw))
+
+    def tanh(self: TensorType) -> TensorType:
+        return type(self)(torch.tanh(self.raw))
+
+    def arcsin(self: TensorType) -> TensorType:
+        return type(self)(torch.asin(self.raw))
+
+    def arccos(self: TensorType) -> TensorType:
+        return type(self)(torch.acos(self.raw))
+
+    def arctan(self: TensorType) -> TensorType:
+        return type(self)(torch.atan(self.raw))
+
+    def arcsinh(self: TensorType) -> TensorType:
+        try:
+            return type(self)(torch.asinh(self.raw))
+        except AttributeError:
+            # Pytorch < 1.6.0 lacks hyperbolic inverses
+            # (see https://github.com/pytorch/pytorch/issues/10324)
+            return type(self)(torch.log(self.raw + (self.raw ** 2 + 1) ** 0.5))
+
+    def arccosh(self: TensorType) -> TensorType:
+        try:
+            return type(self)(torch.acosh(self.raw))
+        except AttributeError:
+            return type(self)(torch.log(self.raw + (self.raw ** 2 - 1) ** 0.5))
+
     def arctanh(self: TensorType) -> TensorType:
-        """
-        improve once this issue has been fixed:
-        https://github.com/pytorch/pytorch/issues/10324
-        """
-        return type(self)(0.5 * (torch.log1p(self.raw) - torch.log1p(-self.raw)))
+        try:
+            return type(self)(torch.atanh(self.raw))
+        except AttributeError:
+            return type(self)(0.5 * (torch.log1p(self.raw) - torch.log1p(-self.raw)))
 
     def sum(
         self: TensorType, axis: Optional[AxisAxes] = None, keepdims: bool = False

--- a/eagerpy/tensor/tensor.py
+++ b/eagerpy/tensor/tensor.py
@@ -202,7 +202,51 @@ class Tensor(metaclass=ABCMeta):
         ...
 
     @abstractmethod
+    def sin(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def cos(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def tan(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def sinh(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def cosh(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
     def tanh(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def arcsin(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def arccos(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def arctan(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def arcsinh(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def arccosh(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def arctanh(self: TensorType) -> TensorType:
         ...
 
     @abstractmethod
@@ -249,10 +293,6 @@ class Tensor(metaclass=ABCMeta):
 
     @abstractmethod
     def square(self: TensorType) -> TensorType:
-        ...
-
-    @abstractmethod
-    def arctanh(self: TensorType) -> TensorType:
         ...
 
     @abstractmethod

--- a/eagerpy/tensor/tensorflow.py
+++ b/eagerpy/tensor/tensorflow.py
@@ -122,9 +122,6 @@ class TensorFlowTensor(BaseTensor):
     def square(self: TensorType) -> TensorType:
         return type(self)(tf.square(self.raw))
 
-    def arctanh(self: TensorType) -> TensorType:
-        return type(self)(tf.atanh(self.raw))
-
     def sum(
         self: TensorType, axis: Optional[AxisAxes] = None, keepdims: bool = False
     ) -> TensorType:
@@ -495,8 +492,41 @@ class TensorFlowTensor(BaseTensor):
     def sqrt(self: TensorType) -> TensorType:
         return type(self)(tf.sqrt(self.raw))
 
+    def sin(self: TensorType) -> TensorType:
+        return type(self)(tf.sin(self.raw))
+
+    def cos(self: TensorType) -> TensorType:
+        return type(self)(tf.cos(self.raw))
+
+    def tan(self: TensorType) -> TensorType:
+        return type(self)(tf.tan(self.raw))
+
+    def sinh(self: TensorType) -> TensorType:
+        return type(self)(tf.sinh(self.raw))
+
+    def cosh(self: TensorType) -> TensorType:
+        return type(self)(tf.cosh(self.raw))
+
     def tanh(self: TensorType) -> TensorType:
         return type(self)(tf.tanh(self.raw))
+
+    def arcsin(self: TensorType) -> TensorType:
+        return type(self)(tf.asin(self.raw))
+
+    def arccos(self: TensorType) -> TensorType:
+        return type(self)(tf.acos(self.raw))
+
+    def arctan(self: TensorType) -> TensorType:
+        return type(self)(tf.atan(self.raw))
+
+    def arcsinh(self: TensorType) -> TensorType:
+        return type(self)(tf.asinh(self.raw))
+
+    def arccosh(self: TensorType) -> TensorType:
+        return type(self)(tf.acosh(self.raw))
+
+    def arctanh(self: TensorType) -> TensorType:
+        return type(self)(tf.atanh(self.raw))
 
     def float32(self: TensorType) -> TensorType:
         return self.astype(tf.float32)

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -16,7 +16,6 @@ generate:
     - eagerpy.Tensor:
         - eagerpy.Tensor.sign
         - eagerpy.Tensor.sqrt
-        - eagerpy.Tensor.tanh
         - eagerpy.Tensor.float32
         - eagerpy.Tensor.where
         - eagerpy.Tensor.matmul
@@ -29,6 +28,17 @@ generate:
         - eagerpy.Tensor.astype
         - eagerpy.Tensor.clip
         - eagerpy.Tensor.square
+        - eagerpy.Tensor.sin
+        - eagerpy.Tensor.cos
+        - eagerpy.Tensor.tan
+        - eagerpy.Tensor.sinh
+        - eagerpy.Tensor.cosh
+        - eagerpy.Tensor.tanh
+        - eagerpy.Tensor.arcsin
+        - eagerpy.Tensor.arccos
+        - eagerpy.Tensor.arctan
+        - eagerpy.Tensor.arcsinh
+        - eagerpy.Tensor.arccosh
         - eagerpy.Tensor.arctanh
         - eagerpy.Tensor.sum
         - eagerpy.Tensor.prod

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1003,12 +1003,66 @@ def test_log1p(t: Tensor) -> Tensor:
 
 
 @compare_allclose(rtol=1e-6)
+def test_sin(t: Tensor) -> Tensor:
+    return ep.sin(t)
+
+
+@compare_allclose(rtol=1e-6)
+def test_cos(t: Tensor) -> Tensor:
+    return ep.cos(t)
+
+
+@compare_allclose(rtol=1e-6)
+def test_tan(t: Tensor) -> Tensor:
+    return ep.tan(t)
+
+
+@compare_allclose(rtol=1e-6)
+def test_sinh(t: Tensor) -> Tensor:
+    return ep.sinh(t)
+
+
+@compare_allclose(rtol=1e-6)
+def test_cosh(t: Tensor) -> Tensor:
+    return ep.cosh(t)
+
+
+@compare_allclose(rtol=1e-6)
 def test_tanh(t: Tensor) -> Tensor:
     return ep.tanh(t)
 
 
 @compare_allclose(rtol=1e-6)
+def test_arcsin(t: Tensor) -> Tensor:
+    # domain is [-1, 1]
+    return ep.arcsin((t - t.mean()) / t.max())
+
+
+@compare_allclose(rtol=1e-6)
+def test_arccos(t: Tensor) -> Tensor:
+    # domain is [-1, 1]
+    return ep.arccos((t - t.mean()) / t.max())
+
+
+@compare_allclose(rtol=1e-6)
+def test_arctan(t: Tensor) -> Tensor:
+    return ep.arctan(t)
+
+
+@compare_allclose(rtol=1e-6)
+def test_arcsinh(t: Tensor) -> Tensor:
+    return ep.arcsinh(t)
+
+
+@compare_allclose(rtol=1e-6)
+def test_arccosh(t: Tensor) -> Tensor:
+    # domain is [1, inf)
+    return ep.arccosh(1 + t - t.min())
+
+
+@compare_allclose(rtol=1e-6)
 def test_arctanh(t: Tensor) -> Tensor:
+    # domain is [-1, 1]
     return ep.arctanh((t - t.mean()) / t.max())
 
 


### PR DESCRIPTION
First of all, thanks for creating this great package!

This PR adds the twelve basic trigonometric functions -- sin, cos, tan, their hyperbolics, inverses, and inverse hyperbolics. Currently eagerpy only has tanh and arctanh.

PyTorch added inverse hyperbolics in 1.6.0 / July 2020. Since eagerpy's test builds still use torch 1.4.0, the implementation falls back to (less numerically stable) implementations in terms of logarithms if needed.