### PR TITLE
Add round, ceil and floor

### DIFF
--- a/eagerpy/framework.py
+++ b/eagerpy/framework.py
@@ -420,3 +420,15 @@ def flatten(t: TensorType, start: int = 0, end: int = -1) -> TensorType:
 
 def inv(t: TensorType) -> TensorType:
     return t.inv()
+
+
+def round(t: TensorType) -> TensorType:
+    return t.round()
+
+
+def ceil(t: TensorType) -> TensorType:
+    return t.ceil()
+
+
+def floor(t: TensorType) -> TensorType:
+    return t.floor()

--- a/eagerpy/tensor/extensions.py
+++ b/eagerpy/tensor/extensions.py
@@ -35,7 +35,6 @@ if hasattr(typing, "GenericMeta"):  # Python 3.6
     class GenericExtensionMeta(typing.GenericMeta, ExtensionMeta):
         pass
 
-
 else:  # pragma: no cover  # Python 3.7 and newer
 
     class GenericExtensionMeta(ExtensionMeta):  # type: ignore

--- a/eagerpy/tensor/jax.py
+++ b/eagerpy/tensor/jax.py
@@ -524,6 +524,15 @@ class JAXTensor(BaseTensor):
     def inv(self: TensorType) -> TensorType:
         return type(self)(jnp.linalg.inv(self.raw))
 
+    def round(self: TensorType) -> TensorType:
+        return type(self)(jnp.round(self.raw))
+
+    def ceil(self: TensorType) -> TensorType:
+        return type(self)(jnp.ceil(self.raw))
+
+    def floor(self: TensorType) -> TensorType:
+        return type(self)(jnp.floor(self.raw))
+
     def float32(self: TensorType) -> TensorType:
         return self.astype(jnp.float32)
 

--- a/eagerpy/tensor/numpy.py
+++ b/eagerpy/tensor/numpy.py
@@ -424,6 +424,15 @@ class NumPyTensor(BaseTensor):
     def inv(self: TensorType) -> TensorType:
         return type(self)(np.linalg.inv(self.raw))
 
+    def round(self: TensorType) -> TensorType:
+        return type(self)(np.round(self.raw))
+
+    def ceil(self: TensorType) -> TensorType:
+        return type(self)(np.ceil(self.raw))
+
+    def floor(self: TensorType) -> TensorType:
+        return type(self)(np.floor(self.raw))
+
     def float32(self: TensorType) -> TensorType:
         return self.astype(np.float32)
 

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -561,6 +561,15 @@ class PyTorchTensor(BaseTensor):
     def inv(self: TensorType) -> TensorType:
         return type(self)(torch.linalg.inv(self.raw))
 
+    def round(self: TensorType) -> TensorType:
+        return type(self)(torch.round(self.raw))
+
+    def ceil(self: TensorType) -> TensorType:
+        return type(self)(torch.ceil(self.raw))
+
+    def floor(self: TensorType) -> TensorType:
+        return type(self)(torch.floor(self.raw))
+
     def float32(self: TensorType) -> TensorType:
         return self.astype(torch.float32)
 

--- a/eagerpy/tensor/tensor.py
+++ b/eagerpy/tensor/tensor.py
@@ -254,6 +254,18 @@ class Tensor(metaclass=ABCMeta):
         ...
 
     @abstractmethod
+    def round(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def ceil(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
+    def floor(self: TensorType) -> TensorType:
+        ...
+
+    @abstractmethod
     def float32(self: TensorType) -> TensorType:
         ...
 

--- a/eagerpy/tensor/tensorflow.py
+++ b/eagerpy/tensor/tensorflow.py
@@ -531,6 +531,15 @@ class TensorFlowTensor(BaseTensor):
     def inv(self: TensorType) -> TensorType:
         return type(self)(tf.linalg.inv(self.raw))
 
+    def round(self: TensorType) -> TensorType:
+        return type(self)(tf.math.round(self.raw))
+
+    def ceil(self: TensorType) -> TensorType:
+        return type(self)(tf.math.ceil(self.raw))
+
+    def floor(self: TensorType) -> TensorType:
+        return type(self)(tf.math.floor(self.raw))
+
     def float32(self: TensorType) -> TensorType:
         return self.astype(tf.float32)
 

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -17,6 +17,9 @@ generate:
         - eagerpy.Tensor.sign
         - eagerpy.Tensor.sqrt
         - eagerpy.Tensor.inv
+        - eagerpy.Tensor.round
+        - eagerpy.Tensor.ceil
+        - eagerpy.Tensor.floor
         - eagerpy.Tensor.float32
         - eagerpy.Tensor.where
         - eagerpy.Tensor.matmul

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -252,6 +252,36 @@ def test_inv(dummy: Tensor) -> None:
     np.testing.assert_allclose(t, n, rtol=1e-6)
 
 
+def test_round(dummy: Tensor) -> None:
+    x = ep.from_numpy(dummy, np.linspace(0, 5, 13))
+    n = np.array([0, 0, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5], dtype=float)
+
+    t = ep.round(x)
+    t = t.numpy()
+    assert t.shape == n.shape
+    np.testing.assert_allclose(t, n, rtol=1e-6)
+
+
+def test_ceil(dummy: Tensor) -> None:
+    x = ep.from_numpy(dummy, np.linspace(0, 5, 13))
+    n = np.array([0, 1, 1, 2, 2, 3, 3, 3, 4, 4, 5, 5, 5], dtype=float)
+
+    t = ep.ceil(x)
+    t = t.numpy()
+    assert t.shape == n.shape
+    np.testing.assert_allclose(t, n, rtol=1e-6)
+
+
+def test_floor(dummy: Tensor) -> None:
+    x = ep.from_numpy(dummy, np.linspace(0, 5, 13))
+    n = np.array([0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5], dtype=float)
+
+    t = ep.floor(x)
+    t = t.numpy()
+    assert t.shape == n.shape
+    np.testing.assert_allclose(t, n, rtol=1e-6)
+
+
 def test_onehot_like_raises(dummy: Tensor) -> None:
     t = ep.arange(dummy, 18).float32().reshape((6, 3))
     indices = ep.arange(t, 6) // 2


### PR DESCRIPTION
Hi again! With this PR, I'd like to add rounding functions like `round`, `ceil` and `floor`.
I've added non-decorated tests for those, but I'm not sure whether you want tests with the `compare_all` decorator instead.
Let me know if you'd like something changed.