### PR TITLE
Correctly compute gradients for torch backend

### DIFF
--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -85,7 +85,7 @@ class PyTorchTensor(BaseTensor):
         return type(self)(self.raw.clamp(min_, max_))
 
     def square(self: TensorType) -> TensorType:
-        return type(self)(self.raw ** 2)
+        return type(self)(self.raw**2)
 
     def sin(self: TensorType) -> TensorType:
         return type(self)(torch.sin(self.raw))

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -530,7 +530,7 @@ class PyTorchTensor(BaseTensor):
             else:
                 loss = f(x, *args, **kwargs)
             loss = loss.raw
-            grad = torch.autograd.grad(loss, x.raw)
+            grad = torch.autograd.grad(loss, x.raw)[0]
             grad = type(self)(grad)
             assert grad.shape == x.shape
             loss = loss.detach()

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -530,9 +530,8 @@ class PyTorchTensor(BaseTensor):
             else:
                 loss = f(x, *args, **kwargs)
             loss = loss.raw
-            loss.backward()
-            assert x.raw.grad is not None
-            grad = type(self)(x.raw.grad)
+            grad = torch.autograd.grad(loss, x)
+            grad = type(self)(grad)
             assert grad.shape == x.shape
             loss = loss.detach()
             loss = type(self)(loss)

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -530,8 +530,8 @@ class PyTorchTensor(BaseTensor):
             else:
                 loss = f(x, *args, **kwargs)
             loss = loss.raw
-            grad = torch.autograd.grad(loss, x.raw)[0]
-            grad = type(self)(grad)
+            grad_raw = torch.autograd.grad(loss, x.raw)[0]
+            grad = type(self)(grad_raw)
             assert grad.shape == x.shape
             loss = loss.detach()
             loss = type(self)(loss)

--- a/eagerpy/tensor/pytorch.py
+++ b/eagerpy/tensor/pytorch.py
@@ -530,7 +530,7 @@ class PyTorchTensor(BaseTensor):
             else:
                 loss = f(x, *args, **kwargs)
             loss = loss.raw
-            grad = torch.autograd.grad(loss, x)
+            grad = torch.autograd.grad(loss, x.raw)
             grad = type(self)(grad)
             assert grad.shape == x.shape
             loss = loss.detach()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 flake8==3.8.3
-black==21.12b0
+black==22.3.0
 pytest==5.4.3
 pytest-cov==2.10.0
 coverage==5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 torch==1.9.0
 jaxlib==0.1.69
 jax==0.2.17
-tensorflow==2.7.0
+tensorflow==2.7.3

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -186,6 +186,21 @@ def test_value_and_grad(dummy: Tensor) -> None:
     assert (g == 2 * t).all()
 
 
+def test_value_and_grad_repeated_calls(dummy: Tensor) -> None:
+    if isinstance(dummy, ep.NumPyTensor):
+        pytest.skip()
+
+    def f(x: Tensor) -> Tensor:
+        return x.square().sum()
+
+    t = ep.arange(dummy, 8).float32().reshape((2, 4))
+    v1, g1 = ep.value_and_grad(f, t)
+    v2, g2 = ep.value_and_grad(f, t)
+    assert v1.item() == 140 == v2.item()
+    assert (g1 == 2 * t).all()
+    assert (g2 == 2 * t).all()
+
+
 def test_value_aux_and_grad(dummy: Tensor) -> None:
     if isinstance(dummy, ep.NumPyTensor):
         pytest.skip()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -551,7 +551,7 @@ def test_pow_float(t: Tensor) -> Tensor:
 
 @compare_allclose(rtol=1e-6)
 def test_pow_op(t: Tensor) -> Tensor:
-    return t ** 3
+    return t**3
 
 
 @compare_allclose(rtol=1e-5)


### PR DESCRIPTION
Currently, the computation of gradients using `value_and_grad` for torch tensors has the problem of storing the gradients in the model. This can become an issue for adversarial training. This PR is meant to solve this issue.

This PR also updates the required versions of tensorflow and black to solve some incompatibility issues with packages they depend on.